### PR TITLE
Don't include last upsampling layer in DeepLabV3 decoder

### DIFF
--- a/coral_deeplab/_blocks.py
+++ b/coral_deeplab/_blocks.py
@@ -155,18 +155,13 @@ def deeplab_aspp_module(inputs: tf.Tensor) -> tf.Tensor:
     return outputs
 
 
-def deeplabv3_decoder(inputs: tf.Tensor, output_shape: tuple,
-                      n_classes: int) -> tf.Tensor:
+def deeplabv3_decoder(inputs: tf.Tensor, n_classes: int) -> tf.Tensor:
     """Implements DeepLabV3 decoder module.
 
     Arguments
     ---------
     inputs : tf.Tensor
         Input tensor.
-
-    output_shape : tuple
-        Tuple with integers specifying HxW
-        shape of logits.
 
     n_classes : int
         Number of segmentation classes to output
@@ -178,12 +173,9 @@ def deeplabv3_decoder(inputs: tf.Tensor, output_shape: tuple,
         Output tensor.
     """
 
-    x = Conv2D(n_classes, 1, padding='same',
-               kernel_regularizer=tf.keras.regularizers.L2(L2),
-               name='logits/semantic')(inputs)
-    outputs = Lambda(
-        lambda t: tf.compat.v1.image.resize_bilinear(
-            t, output_shape, align_corners=True))(x)
+    outputs = Conv2D(n_classes, 1, padding='same',
+                     kernel_regularizer=tf.keras.regularizers.L2(L2),
+                     name='logits/semantic')(inputs)
 
     return outputs
 

--- a/coral_deeplab/applications.py
+++ b/coral_deeplab/applications.py
@@ -68,6 +68,8 @@ def CoralDeepLabV3(input_shape: tuple = (513, 513, 3),
     Notes
     -----
     There is no last activation layer. Model outputs logits.
+    Last layer in the decoder (bilinear upsampling) has been
+    removed for performance reasons, making this model OS16.
 
     Examples
     --------
@@ -88,7 +90,7 @@ def CoralDeepLabV3(input_shape: tuple = (513, 513, 3),
     inputs = Input(shape=input_shape)
     aspp_in = mobilenetv2(inputs)
     aspp_out = deeplab_aspp_module(aspp_in)
-    outputs = deeplabv3_decoder(aspp_out, input_shape[:2], n_classes)
+    outputs = deeplabv3_decoder(aspp_out, n_classes)
     name = 'CoralDeeplabV3'
     model = tf.keras.Model(inputs=inputs, outputs=outputs, name=name)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 numpy>=1.19.5
-tensorflow>=2.4.0
+tensorflow==2.4.0

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -38,7 +38,7 @@ def quantize_and_compile(model, dataset):
     open(model_path, 'wb').write(quantized)
 
     # compile
-    cmd = ['edgetpu_compiler', '-s', model_path]
+    cmd = ['edgetpu_compiler', '-a', '-s', model_path]
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     p.wait()
     stdout = p.stdout.read()

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -62,16 +62,6 @@ class TestCoralDeepLabV3Plus(unittest.TestCase):
             input_shape = (112, 224, 3)
             cdl.applications.CoralDeepLabV3(input_shape)
 
-    def test_input_match_output(self):
-        """Test if output shape matches input"""
-
-        supported_shapes = [192, 224, 513]
-        for shape in supported_shapes:
-            input_shape = (shape, shape, 3)
-            model = cdl.applications.CoralDeepLabV3(input_shape)
-            _, *out_shape, _ = model.output_shape
-            self.assertEqual(tuple(out_shape), input_shape[:-1])
-
     @unittest.skipUnless(sys.platform.startswith('linux'), 'linux required')
     def test_edgetpu_compiles(self):
         """Test if model compiles to Edge TPU across input ranges"""


### PR DESCRIPTION
This layer can't run on EdgeTPU anyway, so it makes sense to remove it from the model. This change essentially makes model OS16, and leaves final upsampling to end user, but model can now run all heavy operations on EdgeTPU.