### PR TITLE
Use `edgetpu-compiler` v14.1 in CI

### DIFF
--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -30,12 +30,6 @@ jobs:
         pip install --upgrade setuptools
         pip install -r requirements.txt
         pip install flake8
-    
-    - name: Install Edge TPU compiler
-      run: |
-        chmod +x compiler/compiler.sh
-        ./compiler/compiler.sh
-        edgetpu_compiler -v
 
     - name: Lint
       run: |

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -32,19 +32,11 @@ jobs:
         pip install flake8
     
     - name: Install Edge TPU compiler
-      # can't compile models with edgetpu-compiler v16.0 from distribution
-      # so temporarily pulling v14.0 from edgetpu repo
-      # run : |
-      #   curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-      #   echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list
-      #   sudo apt-get update
-      #   sudo apt-get install edgetpu-compiler
-      #   edgetpu_compiler -v
       run: |
         chmod +x compiler/compiler.sh
         ./compiler/compiler.sh
         edgetpu_compiler -v
-    
+
     - name: Lint
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -32,11 +32,17 @@ jobs:
         pip install flake8
     
     - name: Install Edge TPU compiler
-      run : |
-        curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-        echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list
-        sudo apt-get update
-        sudo apt-get install edgetpu-compiler
+      # can't compile models with edgetpu-compiler v16.0 from distribution
+      # so temporarily pulling v14.0 from edgetpu repo
+      # run : |
+      #   curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+      #   echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list
+      #   sudo apt-get update
+      #   sudo apt-get install edgetpu-compiler
+      #   edgetpu_compiler -v
+      run: |
+        chmod +x compiler/compiler.sh
+        ./compiler/compiler.sh
         edgetpu_compiler -v
     
     - name: Lint

--- a/compiler/compiler.sh
+++ b/compiler/compiler.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+curl -H "Accept: application/vnd.github.v3+json" -L https://api.github.com/repos/google-coral/edgetpu/tarball/master | \
+  tar -xz --strip=2 google-coral-edgetpu-6d69966/compiler/x86_64/
+sudo mv x86_64/* /usr/local/bin
+edgetpu_compiler -v


### PR DESCRIPTION
The release of compiler v16.0 broke model compatibility. That's why legacy compiler needs to be used for now.