### PR TITLE
Use `edgetpu-compiler` v14.1 in CI (redo)

### DIFF
--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -33,12 +33,10 @@ jobs:
     
     - name: Install Edge TPU compiler
       run : |
-        curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-        echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list
-        sudo apt-get update
-        sudo apt-get install edgetpu-compiler
+        chmod +x compiler/compiler.sh
+        ./compiler/compiler.sh
         edgetpu_compiler -v
-    
+
     - name: Lint
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/compiler/compiler.sh
+++ b/compiler/compiler.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+curl -H "Accept: application/vnd.github.v3+json" -L https://api.github.com/repos/google-coral/edgetpu/tarball/master | \
+  tar -xz --strip=2 google-coral-edgetpu-6d69966/compiler/x86_64/
+sudo mv x86_64/* /usr/local/bin
+edgetpu_compiler -v


### PR DESCRIPTION
The release of compiler v16.0 broke model compatibility. That's why legacy compiler needs to be used for now.

#16 closed due to GitHub actions outage.