### PR TITLE
Temporarily disable access to pre-trained keras model weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # coral-deeplab
 
-[Coral Edge TPU](https://coral.ai/products/) compilable version of DeepLab v3 and DeepLab v3 Plus implemented in `tf.keras` with pretrained weights and Edge TPU pre-compiled models included.
+[Coral Edge TPU](https://coral.ai/products/) compilable version of DeepLab v3 and DeepLab v3 Plus implemented in `tf.keras` with Edge TPU pre-compiled models included.
 
 Implementation follows original paper as close as possible, while still being compatible with Edge TPU. The only difference is that last upsampling layer has been removed from decoder due to performance reasons. Thanks to multi subgraph support in `edgetpu_compiler`, model runs almost all operations on TPU, where [original model](https://coral.ai/models/semantic-segmentation/) delegates entirety of decoder to run on CPU.
-
-Thanks to pretrained weights and `tf.keras` implementation it's easy to fine tune this model, or even train it from scratch.
 
 ## Instalation
 
@@ -21,17 +19,6 @@ import tensorflow as tf
 import coral_deeplab as cdl
 
 model = cdl.applications.CoralDeepLabV3()
-isinstance(model, tf.keras.Model)
-# True
-```
-
-...finetune...
-
-```python
-import tensorflow as tf
-import coral_deeplab as cdl
-
-model = cdl.applications.CoralDeepLabV3(weights="pascal_voc")
 isinstance(model, tf.keras.Model)
 # True
 ```

--- a/coral_deeplab/applications.py
+++ b/coral_deeplab/applications.py
@@ -20,14 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Optional
-
 import numpy as np
 import tensorflow as tf
 from tensorflow.keras.layers import Input
 
-from coral_deeplab import pretrained
-from coral_deeplab._downloads import download_and_checksum_mlmodel
 from coral_deeplab._encoders import mobilenetv2
 from coral_deeplab._blocks import (
     deeplab_aspp_module,
@@ -41,7 +37,6 @@ __all__ = ['CoralDeepLabV3', 'CoralDeepLabV3Plus']
 
 def CoralDeepLabV3(input_shape: tuple = (513, 513, 3),
                    alpha: float = 1.0,
-                   weights: Optional[str] = None,
                    n_classes: int = 30, **kwargs) -> tf.keras.Model:
     """DeepLab v3 implementation compilable to coral.ai Edge TPU.
 
@@ -60,10 +55,6 @@ def CoralDeepLabV3(input_shape: tuple = (513, 513, 3),
     alpha : float, default=1.0
         Float between 0. and 1.
         MobileNetV2 depth multiplier.
-
-    weights : str, default=None
-        One of None (random initialization) or `pascal_voc`
-        (pre-training on Pascal VOC trainaug set).
 
     n_classes : int, default=30
         Number of segmentation classes.
@@ -94,19 +85,6 @@ def CoralDeepLabV3(input_shape: tuple = (513, 513, 3),
     'CoralDeepLabV3'
     """
 
-    if weights == 'pascal_voc':
-        if alpha == 0.5:
-            model_type = pretrained.KerasModel.DEEPLAB_V3_DM05
-
-        else:
-            # alpha 1.0 and default fallback for unsupported depths.
-            model_type = pretrained.KerasModel.DEEPLAB_V3_DM1
-
-        model_path = download_and_checksum_mlmodel(model_type)
-        model = tf.keras.models.load_model(
-            model_path, custom_objects={'tf': tf}, compile=False)
-        return model
-
     if np.argmin(input_shape) == 0:
         # assuming channels always
         # gonna be smallest number
@@ -127,7 +105,6 @@ def CoralDeepLabV3(input_shape: tuple = (513, 513, 3),
 
 def CoralDeepLabV3Plus(input_shape: tuple = (513, 513, 3),
                        alpha: float = 1.0,
-                       weights: Optional[str] = None,
                        n_classes: int = 30, **kwargs) -> tf.keras.Model:
     """DeepLabV3 Plus implementation compilable to coral.ai Edge TPU.
 
@@ -146,10 +123,6 @@ def CoralDeepLabV3Plus(input_shape: tuple = (513, 513, 3),
     alpha : float, default=1.0
         Float between 0. and 1.
         MobileNetV2 depth multiplier.
-
-    weights : str, default=None
-        One of None (random initialization) or `pascal_voc`
-        (pre-training on Pascal VOC trainaug set).
 
     n_classes : int, default=30
         Number of segmentation classes.
@@ -181,18 +154,6 @@ def CoralDeepLabV3Plus(input_shape: tuple = (513, 513, 3),
     >>> print(model.name)
     'CoralDeepLabV3Plus'
     """
-
-    if weights == 'pascal_voc':
-        if alpha == 0.5:
-            model_type = pretrained.KerasModel.DEEPLAB_V3_PLUS_DM05
-
-        else:
-            model_type = pretrained.KerasModel.DEEPLAB_V3_PLUS_DM1
-
-        model_path = download_and_checksum_mlmodel(model_type)
-        model = tf.keras.models.load_model(
-            model_path, custom_objects={'tf': tf}, compile=False)
-        return model
 
     encoder = CoralDeepLabV3(input_shape, alpha)
     encoder_last = encoder.get_layer('concat_projection/relu')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy>=1.19.5
-tensorflow==2.4.0
+numpy<=1.24.0
+tensorflow-gpu>=2.4.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     python_requires='==3.7.*',
     install_requires=[
-        'numpy>=1.19.5',
-        'tensorflow-gpu==2.4.0'
+        'numpy<=1.24.0',
+        'tensorflow-gpu>=2.4.0'
     ]
 )

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -87,7 +87,7 @@ class TestCoralDeepLabV3(unittest.TestCase):
                 msg = f'Model not compiled for shape {input_shape}'
                 self.fail(msg)
 
-    @unittest.skipUnless(sys.platform.startswith('linux'), 'linux required')
+    @unittest.skip('Finetuning was temporarily disabled.')
     def test_dlv3_pretrained_edgetpu_compile(self):
         """Test if model compiles from pretrained weights"""
 
@@ -118,7 +118,7 @@ class TestCoralDeepLabV3(unittest.TestCase):
                 self.fail('Failed to compile DeepLabV3Plus '
                           f'with input shape {input_shape}')
 
-    @unittest.skipUnless(sys.platform.startswith('linux'), 'linux required')
+    @unittest.skip('Finetuning was temporarily disabled.')
     def test_dlv3plus_pretrained_edgetpu_compile(self):
         """Test if pretrained DeepLabV3Plus model compiles to Edge TPU"""
 


### PR DESCRIPTION
As mentioned in https://github.com/xadrianzetx/coral-deeplab/issues/23#issuecomment-1362045077, finetuning is temporarily disabled due to issues related to model unmarshalling between different Python versions. This allows to unpin Python and library dependencies, enabling users to use current releases.