### PR TITLE
Unpin Python

### DIFF
--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -14,7 +14,7 @@ jobs:
     
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade setuptools
-        pip install -r requirements.txt
+        pip install 'numpy<=1.24.0' 'tensorflow-gpu>=2.4.0'
         pip install flake8
     
     - name: Install Edge TPU compiler

--- a/coral_deeplab/__init__.py
+++ b/coral_deeplab/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.2'
+__version__ = '0.3'
 
 from . import pretrained
 from ._downloads import from_precompiled

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-numpy<=1.24.0
-tensorflow-gpu>=2.4.0

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,18 @@ setup(
     long_description_content_type='text/markdown',
     packages=find_packages(include=['coral_deeplab']),
     classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Topic :: Scientific/Engineering :: Artificial Intelligence'
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3 :: Only',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
     ],
-    python_requires='==3.7.*',
+    python_requires='>=3.7',
     install_requires=[
         'numpy<=1.24.0',
         'tensorflow-gpu>=2.4.0'


### PR DESCRIPTION
Follow up to #23 and #25. Python 3.11 will be supported after https://github.com/tensorflow/tensorflow/issues/58032 is closed.